### PR TITLE
Use HomeKit Television service type

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,18 @@ Homebridge module for Philips TV (with JointSpace enabled) with Power on/off, So
 
 # Description
 
-This plugin is a fork of [homebridge-philipstv-x](https://www.npmjs.com/package/homebridge-philipstv-x) with additional support for Sound control, Ambilight brightness control and input selection control.
-It has been modified to work on a 43PUS6753 TV (2018 model without Android) and may not work on older one. Code may need ajustement for Ambilight to work on other 2018 models
+This plugin is a fork of [gw-wiscon](https://github.com/gw-wiscon)'s
+[homebridge-philipstv-x](https://www.npmjs.com/package/homebridge-philipstv-x)
+with additional support for Sound control, Ambilight brightness control and
+input selection control by [jebabin](https://github.com/jebabin).
+It has been modified to work on a 43PUS6753 TV (2018 model without Android)
+and may not work on older one. Code may need ajustement for Ambilight to work
+on other 2018 models.
+
+This was further modified by [Arkku](https://github.com/arkku) to use the
+HomeKit Television service, which allows remote control from the Control Center
+widget (including volume control by pressing the physical volume up/down
+buttons).
 
 # Installation
 
@@ -15,6 +25,7 @@ It has been modified to work on a 43PUS6753 TV (2018 model without Android) and 
 # Configuration
  
 Example accessory config (needs to be added to the homebridge config.json):
+
   ```
  "accessories": [
  	{
@@ -25,6 +36,9 @@ Example accessory config (needs to be added to the homebridge config.json):
 		"model_year": 2018,
 		"has_ssl": false,
 		"has_ambilight": true,
+		"hide_input_selector": false,
+		"info_button": "Source",
+		"playpause_button": "Options"
  	}
  ]
   ```
@@ -45,6 +59,13 @@ Added test option for WakeOnWLAN:
 	}
 ]
  ```
+
+The Control Center widget info button is mapped to the options menu by default,
+but may be configured to any other remote button (e.g., `Home` or `Source`)
+with the option `"info_button": "Options"`. Likewise the play/pause button may
+be remapped, with `"playpause_button": "PlayPause"`. The somewhat flaky input
+source selector (which simply sends a sequence of buttons, hoping to change the
+input) may be disabled with `"hide_input_selector": true`.
 
 # Credentials for 2016 (and newer?) models with Android TV
 

--- a/README.md
+++ b/README.md
@@ -34,11 +34,13 @@ Example accessory config (needs to be added to the homebridge config.json):
  		"ip_address": "10.0.1.23",
  		"poll_status_interval": "60",
 		"model_year": 2018,
-		"has_ssl": false,
+		"has_ssl": true,
 		"has_ambilight": true,
+                "has_chromecast": true,
 		"hide_input_selector": false,
 		"info_button": "Source",
-		"playpause_button": "Options"
+		"playpause_button": "Options",
+		"wol_url": "wol://18:8e:d5:a2:8c:66"
  	}
  ]
   ```

--- a/README.md
+++ b/README.md
@@ -14,53 +14,72 @@ on other 2018 models.
 This was further modified by [Arkku](https://github.com/arkku) to use the
 HomeKit Television service, which allows remote control from the Control Center
 widget (including volume control by pressing the physical volume up/down
-buttons).
+buttons). Other modifications include ChromeCast-based power-on option, and
+support for an external "etherwake" executable.
 
 # Installation
 
-1. Install homebridge using: npm install -g homebridge
-2. Install this plugin using: npm install -g homebridge-philipstv-enhanced
+1. Install homebridge using: `npm install -g homebridge`
+2. Install this plugin using: `npm install -g homebridge-philipstv-enhanced`
 3. Update your configuration file. See the sample below.
+
+If you do not wish to install from npm (e.g, because you are using a fork), you
+may also clone the git repository into some directory like
+`/usr/local/homebridge/plugins/homebridge-philipstv-enhanced` and then specify the
+plugin directory as an option (`-P /usr/local/homebridge/plugins`, typically
+using `HOMEBRIDGE_OPTS` in `/etc/default/homebridge`).
 
 # Configuration
  
-Example accessory config (needs to be added to the homebridge config.json):
+Example accessory config (needs to be added to the Homebridge `config.json`):
 
   ```
  "accessories": [
- 	{
- 		"accessory": "PhilipsTV",
- 		"name": "TV",
- 		"ip_address": "10.0.1.23",
- 		"poll_status_interval": "60",
-		"model_year": 2018,
-		"has_ssl": true,
-		"has_ambilight": true,
-                "has_chromecast": true,
-		"hide_input_selector": false,
-		"info_button": "Source",
-		"playpause_button": "Options",
-		"wol_url": "wol://18:8e:d5:a2:8c:66"
- 	}
+     {
+        "accessory": "PhilipsTV",
+        "name": "TV",
+        "ip_address": "10.0.1.23",
+        "poll_status_interval": "60",
+        "model_year": 2018,
+        "has_ssl": true,
+        "has_ambilight": true,
+        "has_chromecast": true,
+        "hide_input_selector": false,
+        "info_button": "Source",
+        "playpause_button": "Options",
+        "wol_url": "wol://18:8e:d5:a2:8c:66"
+     }
  ]
   ```
  
-To be able to power on the TV when the TV is in standby mode, you will need the wol_url parameters with the mac address of your TV
-Added test option for WakeOnWLAN:
+To be able to power on the TV when the TV is in standby mode, you will need the `wol_url` 
+parameter with the MAC address of your TV. You may also specify
+`etherwake_exec` with a path to the `etherwake` executable (takes the MAC
+address as argument). In some cases this seems to work using
+`/usr/sbin/ethewrake` when the built-in WoL fails, so try both before giving
+up.
 
  ```
 "accessories": [
-	{
-		"accessory": "PhilipsTV",
-		"name": "TV",
-		"ip_address": "10.0.1.23",
-		"poll_status_interval": "60",
-		"model_year" : "2018",
-		"has_ssl": false,
-		"wol_url": "wol://18:8e:d5:a2:8c:66"
-	}
+    {
+        "accessory": "PhilipsTV",
+        "name": "TV",
+        "ip_address": "10.0.1.23",
+        "poll_status_interval": "60",
+        "model_year" : "2018",
+        "has_ssl": false,
+        "wol_url": "wol://18:8e:d5:a2:8c:66",
+        "etherwake_exec": "/usr/sbin/etherwake"
+    }
 ]
  ```
+
+For TVs with a built-in ChromeCast, you may also have better success waking it
+up through that. This is supported with the option `"has_chromecast": true`, in
+which case the ChromeCast URL is accessed before trying using the typical power
+state method. You may need to enable ChromeCast power-up option in the TV settings
+menu (this will increase standby power consumption, so try first if your TV
+wakes up consistently without it).
 
 The Control Center widget info button is mapped to the options menu by default,
 but may be configured to any other remote button (e.g., `Home` or `Source`)

--- a/index.js
+++ b/index.js
@@ -5,195 +5,190 @@ var pollingtoevent = require('polling-to-event');
 var wol = require('wake_on_lan');
 
 module.exports = function(homebridge) {
-    Service = homebridge.hap.Service;
-    Characteristic = homebridge.hap.Characteristic;
-    homebridge.registerAccessory("homebridge-philipstv-enhanced", "PhilipsTV", HttpStatusAccessory);
+	Service = homebridge.hap.Service;
+	Characteristic = homebridge.hap.Characteristic;
+	homebridge.registerAccessory("homebridge-philipstv-enhanced", "PhilipsTV", HttpStatusAccessory);
 }
 
 function HttpStatusAccessory(log, config) {
-    this.log = log;
-    var that = this;
+	this.log = log;
+	var that = this;
 
-    // CONFIG
-    this.ip_address = config["ip_address"];
-    this.name = config["name"];
-    this.poll_status_interval = config["poll_status_interval"] || "0";
-    this.model_year = config["model_year"] || "2018";
-    this.wol_url = config["wol_url"] || "";
-    this.model_year_nr = parseInt(this.model_year);
-    this.set_attempt = 0;
-    this.has_ambilight = config["has_ambilight"] || false;
-    this.has_ssl = config["has_ssl"] || false;
+	// CONFIG
+	this.ip_address = config["ip_address"];
+	this.name = config["name"];
+	this.poll_status_interval = config["poll_status_interval"] || "0";
+	this.model_year = config["model_year"] || "2018";
+	this.wol_url = config["wol_url"] || "";
+	this.model_year_nr = parseInt(this.model_year);
+	this.set_attempt = 0;
+	this.has_ambilight = config["has_ambilight"] || false;
+	this.has_ssl = config["has_ssl"] || false;
+	this.has_input_selector = !(config["hide_input_selector"] || false);
+    this.info_button = config["info_button"] || "Source";
+    this.playpause_button = config["playpause_button"] || "Options";
+	this.serial_number = config["serial_number"] || config["wol_url"] || "123456789";
+	this.enabled_services = [];
 
-    // CREDENTIALS FOR API
-    this.username = config["username"] || "";
-    this.password = config["password"] || "";
+	// CREDENTIALS FOR API
+	this.username = config["username"] || "";
+	this.password = config["password"] || "";
 
-    // CHOOSING API VERSION BY MODEL/YEAR
-    switch (this.model_year_nr) {
-        case 2018:
-            this.api_version = 6;
-            break;
-        case 2017:
-            this.api_version = 6;
-            break;
-        case 2016:
-            this.api_version = 6;
-            break;
-        case 2015:
-            this.api_version = 5;
-            break;
-        case 2014:
-            this.api_version = 5;
-            break;
-        default:
-            this.api_version = 1;
-    }
+	// CHOOSING API VERSION BY MODEL/YEAR
+	if (this.model_year_nr >= 2016) {
+		this.api_version = 6;
+	} else if (this.model_year_nr >= 2014) {
+		this.api_version = 5;
+	} else {
+		this.api_version = 1;
+	}
 
-    // CONNECTION SETTINGS
-    this.protocol = this.has_ssl ? "https" : "http";
-    this.portno = this.has_ssl ? "1926" : "1925";
-    this.need_authentication = this.username != '' ? 1 : 0;
+	// CONNECTION SETTINGS
+	this.protocol = this.has_ssl ? "https" : "http";
+	this.portno = this.has_ssl ? "1926" : "1925";
+	this.need_authentication = this.username != '' ? 1 : 0;
 
-    this.log("Model year: " + this.model_year_nr);
-    this.log("API version: " + this.api_version);
+	this.log("Model year: " + this.model_year_nr);
+	this.log("API version: " + this.api_version);
 
-    this.state_power = true;
-    this.state_ambilight = false;
-    this.state_ambilightLevel = 0;
-    this.state_volume = false;
-    this.state_volumeLevel = 0;
+	this.state_power = true;
+	this.state_ambilight = false;
+	this.state_ambilightLevel = 0;
+	this.state_volume = false;
+	this.state_volumeLevel = 0;
 
-    // Define URL & JSON Payload for Actions
+	// Define URL & JSON Payload for Actions
 
-    // POWER
-    this.power_url = this.protocol + "://" + this.ip_address + ":" + this.portno + "/" + this.api_version + "/powerstate";
-    this.power_on_body = JSON.stringify({
-        "powerstate": "On"
-    });
-    this.power_off_body = JSON.stringify({
-        "powerstate": "Standby"
-    });
+	// POWER
+	this.power_url = this.protocol + "://" + this.ip_address + ":" + this.portno + "/" + this.api_version + "/powerstate";
+	this.power_on_body = JSON.stringify({
+		"powerstate": "On"
+	});
+	this.power_off_body = JSON.stringify({
+		"powerstate": "Standby"
+	});
 
-    // Volume
-    this.audio_url = this.protocol + "://" + this.ip_address + ":" + this.portno + "/" + this.api_version + "/audio/volume";
-    this.audio_unmute_body = JSON.stringify({
-        "muted": false
-    });
-    this.audio_mute_body = JSON.stringify({
-        "muted": true
-    });
+	// Volume
+	this.audio_url = this.protocol + "://" + this.ip_address + ":" + this.portno + "/" + this.api_version + "/audio/volume";
+	this.audio_unmute_body = JSON.stringify({
+		"muted": false
+	});
+	this.audio_mute_body = JSON.stringify({
+		"muted": true
+	});
 
-    // INPUT
-    this.input_url = this.protocol + "://" + this.ip_address + ":" + this.portno + "/" + this.api_version + "/input/key";
+	// INPUT
+	this.input_url = this.protocol + "://" + this.ip_address + ":" + this.portno + "/" + this.api_version + "/input/key";
 
-    // AMBILIGHT
-    this.ambilight_status_url = this.protocol + "://" + this.ip_address + ":" + this.portno + "/" + this.api_version + "/menuitems/settings/current";
+	// AMBILIGHT
+	this.ambilight_status_url = this.protocol + "://" + this.ip_address + ":" + this.portno + "/" + this.api_version + "/menuitems/settings/current";
 	this.ambilight_brightness_body = JSON.stringify({"nodes":[{"nodeid":200}]});
 	this.ambilight_mode_body = JSON.stringify({"nodes":[{"nodeid":100}]});
 	
-    this.ambilight_config_url = this.protocol + "://" + this.ip_address + ":" + this.portno + "/" + this.api_version + "/menuitems/settings/update";
-    this.ambilight_power_on_body = JSON.stringify({"value":{"Nodeid":100,"Controllable":true,"Available":true,"data":{"activenode_id":120}}}); // Follow Video 
-    this.ambilight_power_off_body = JSON.stringify({"value":{"Nodeid":100,"Controllable":true,"Available":true,"data":{"activenode_id":110}}}); // Off
+	this.ambilight_config_url = this.protocol + "://" + this.ip_address + ":" + this.portno + "/" + this.api_version + "/menuitems/settings/update";
+	this.ambilight_power_on_body = JSON.stringify({"value":{"Nodeid":100,"Controllable":true,"Available":true,"data":{"activenode_id":120}}}); // Follow Video 
+	this.ambilight_power_off_body = JSON.stringify({"value":{"Nodeid":100,"Controllable":true,"Available":true,"data":{"activenode_id":110}}}); // Off
 
-    // POLLING ENABLED?
-    this.interval = parseInt(this.poll_status_interval);
-    this.switchHandling = "check";
-    if (this.interval > 10 && this.interval < 100000) {
-        this.switchHandling = "poll";
-    }
+	// POLLING ENABLED?
+	this.interval = parseInt(this.poll_status_interval);
+	this.switchHandling = "check";
+	if (this.interval > 10 && this.interval < 100000) {
+		this.switchHandling = "poll";
+	}
 
-    // STATUS POLLING
-    if (this.switchHandling == "poll") {
-        var statusemitter = pollingtoevent(function(done) {
-            that.getPowerState(function(error, response) {
-                done(error, response, that.set_attempt);
-            }, "statuspoll");
-        }, {
-            longpolling: true,
-            interval: that.interval * 1000,
-            longpollEventName: "statuspoll_power"
-        });
+	// STATUS POLLING
+	if (this.switchHandling == "poll") {
+		var statusemitter = pollingtoevent(function(done) {
+			that.getPowerState(function(error, response) {
+				done(error, response, that.set_attempt);
+			}, "statuspoll");
+		}, {
+			longpolling: true,
+			interval: that.interval * 1000,
+			longpollEventName: "statuspoll_power"
+		});
 
-        statusemitter.on("statuspoll_power", function(data) {
-            that.state_power = data;
-            if (that.switchService) {
-                that.switchService.getCharacteristic(Characteristic.On).setValue(that.state_power, null, "statuspoll");
-            }
-        });
+		statusemitter.on("statuspoll_power", function(data) {
+			that.state_power = data;
+			if (that.switchService) {
+				that.switchService.getCharacteristic(Characteristic.On).setValue(that.state_power, null, "statuspoll");
+			}
+		});
 
-        var statusemitter_volume = pollingtoevent(function(done) {
-            that.getVolumeState(function(error, response) {
-                done(error, response, that.set_attempt);
-            }, "statuspoll");
-        }, {
-            longpolling: true,
-            interval: that.interval * 1000,
-            longpollEventName: "statuspoll_volume"
-        });
+		var statusemitter_volume = pollingtoevent(function(done) {
+			that.getVolumeState(function(error, response) {
+				done(error, response, that.set_attempt);
+			}, "statuspoll");
+		}, {
+			longpolling: true,
+			interval: that.interval * 1000,
+			longpollEventName: "statuspoll_volume"
+		});
 
-        statusemitter.on("statuspoll_volume", function(data) {
-            that.state_volume = data;
-            if (that.VolumeService) {
-                that.VolumeService.getCharacteristic(Characteristic.On).setValue(that.state_volume, null, "statuspoll");
-            }
-        });
+		statusemitter.on("statuspoll_volume", function(data) {
+			that.state_volume = data;
+			if (that.VolumeService) {
+				that.VolumeService.getCharacteristic(Characteristic.On).setValue(that.state_volume, null, "statuspoll");
+			}
+		});
 
-        var statusemitter_volume_level = pollingtoevent(function(done) {
-            that.getVolumeLevel(function(error, response) {
-                done(error, response, that.set_attempt);
-            }, "statuspoll");
-        }, {
-            longpolling: true,
-            interval: that.interval * 1000,
-            longpollEventName: "statuspoll_volumeLevel"
-        });
+		var statusemitter_volume_level = pollingtoevent(function(done) {
+			that.getVolumeLevel(function(error, response) {
+				done(error, response, that.set_attempt);
+			}, "statuspoll");
+		}, {
+			longpolling: true,
+			interval: that.interval * 1000,
+			longpollEventName: "statuspoll_volumeLevel"
+		});
 
-        statusemitter.on("statuspoll_volumeLevel", function(data) {
-            that.state_volumeLevel = data;
-            if (that.VolumeService) {
-                that.VolumeService.getCharacteristic(Characteristic.Brightness).setValue(that.state_volumeLevel, null, "statuspoll");
-            }
-        });
+		statusemitter.on("statuspoll_volumeLevel", function(data) {
+			that.state_volumeLevel = data;
+			if (that.VolumeService) {
+				that.VolumeService.getCharacteristic(Characteristic.Brightness).setValue(that.state_volumeLevel, null, "statuspoll");
+			}
+		});
 
-        if (this.has_ambilight) {
-            var statusemitter_ambilight = pollingtoevent(function(done) {
-                that.getAmbilightState(function(error, response) {
-                    done(error, response, that.set_attempt);
-                }, "statuspoll");
-            }, {
-                longpolling: true,
-                interval: that.interval * 1000,
-                longpollEventName: "statuspoll_ambilight"
-            });
+		if (this.has_ambilight) {
+			var statusemitter_ambilight = pollingtoevent(function(done) {
+				that.getAmbilightState(function(error, response) {
+					done(error, response, that.set_attempt);
+				}, "statuspoll");
+			}, {
+				longpolling: true,
+				interval: that.interval * 1000,
+				longpollEventName: "statuspoll_ambilight"
+			});
 
-            statusemitter_ambilight.on("statuspoll_ambilight", function(data) {
-                that.state_ambilight = data;
-                if (that.ambilightService) {
-                    that.ambilightService.getCharacteristic(Characteristic.On).setValue(that.state_ambilight, null, "statuspoll");
-                }
-            });
-            
-            var statusemitter_ambilight_brightness = pollingtoevent(function(done) {
-                that.getAmbilightBrightness(function(error, response) {
-                    done(error, response, that.set_attempt);
-                }, "statuspoll");
-            }, {
-                longpolling: true,
-                interval: that.interval * 1000,
-                longpollEventName: "statuspoll_ambilight_brightness"
-            });
+			statusemitter_ambilight.on("statuspoll_ambilight", function(data) {
+				that.state_ambilight = data;
+				if (that.ambilightService) {
+					that.ambilightService.getCharacteristic(Characteristic.On).setValue(that.state_ambilight, null, "statuspoll");
+				}
+			});
+			
+			var statusemitter_ambilight_brightness = pollingtoevent(function(done) {
+				that.getAmbilightBrightness(function(error, response) {
+					done(error, response, that.set_attempt);
+				}, "statuspoll");
+			}, {
+				longpolling: true,
+				interval: that.interval * 1000,
+				longpollEventName: "statuspoll_ambilight_brightness"
+			});
 
-            statusemitter_ambilight_brightness.on("statuspoll_ambilight_brightness", function(data) {
-                that.state_ambilight_brightness = data;
-                if (that.ambilightService) {
-                    that.ambilightService.getCharacteristic(Characteristic.Brightness).setValue(that.state_ambilight_brightness, null, "statuspoll");
-                }
-            });            
-            
-            
-        }
-    }
+			statusemitter_ambilight_brightness.on("statuspoll_ambilight_brightness", function(data) {
+				that.state_ambilight_brightness = data;
+				if (that.ambilightService) {
+					that.ambilightService.getCharacteristic(Characteristic.Brightness).setValue(that.state_ambilight_brightness, null, "statuspoll");
+				}
+			});			
+			
+			
+		}
+	}
+
+	this.prepareServices();
 }
 
 /////////////////////////////
@@ -201,122 +196,122 @@ function HttpStatusAccessory(log, config) {
 HttpStatusAccessory.prototype = {
 
 	// Sometime the API fail, all calls should use a retry method, not used yet but goal is to replace all the XLoop function by this generic one
-    httpRequest_with_retry: function(url, body, method, need_authentication, retry_count, callback) {
-        this.httpRequest(url, body, method, need_authentication, function(error, response, responseBody) {
-            if (error) {
-                if (retry_count > 0) {
-                    this.log('Got error, will retry: ', retry_count, ' time(s)');
-                    this.httpRequest_with_retry(url, body, method, need_authentication, retry_count - 1, function(err) {
-                        callback(err);
-                    });
-                } else {
-                    this.log('Request failed: %s', error.message);
-                    callback(new Error("Request attempt failed"));
-                }
-            } else {
-                this.log('succeeded - answer: %s', responseBody);
-                callback(null, response, responseBody);
-            }
-        }.bind(this));
-    },
+	httpRequest_with_retry: function(url, body, method, need_authentication, retry_count, callback) {
+		this.httpRequest(url, body, method, need_authentication, function(error, response, responseBody) {
+			if (error) {
+				if (retry_count > 0) {
+					this.log('Got error, will retry: ', retry_count, ' time(s)');
+					this.httpRequest_with_retry(url, body, method, need_authentication, retry_count - 1, function(err) {
+						callback(err);
+					});
+				} else {
+					this.log('Request failed: %s', error.message);
+					callback(new Error("Request attempt failed"));
+				}
+			} else {
+				this.log('succeeded - answer: %s', responseBody);
+				callback(null, response, responseBody);
+			}
+		}.bind(this));
+	},
 
-    httpRequest: function(url, body, method, need_authentication, callback) {
-        var options = {
-            url: url,
-            body: body,
-            method: method,
-            rejectUnauthorized: false,
-            timeout: 1000
-        };
+	httpRequest: function(url, body, method, need_authentication, callback) {
+		var options = {
+			url: url,
+			body: body,
+			method: method,
+			rejectUnauthorized: false,
+			timeout: 1000
+		};
 
-        // EXTRA CONNECTION SETTINGS FOR API V6 (HTTP DIGEST)
-        if (need_authentication) {
-            options.followAllRedirects = true;
-            options.forever = true;
-            options.auth = {
-                user: this.username,
-                pass: this.password,
-                sendImmediately: false
-            }
-        }
-        
-        req = request(options,
-            function(error, response, body) {
-                callback(error, response, body)
-        	}
-        );
-    },
+		// EXTRA CONNECTION SETTINGS FOR API V6 (HTTP DIGEST)
+		if (need_authentication) {
+			options.followAllRedirects = true;
+			options.forever = true;
+			options.auth = {
+				user: this.username,
+				pass: this.password,
+				sendImmediately: false
+			}
+		}
+		
+		req = request(options,
+			function(error, response, body) {
+				callback(error, response, body)
+			}
+		);
+	},
 
-    wolRequest: function(url, callback) {
-        this.log('calling WOL with URL %s', url);
-        if (!url) {
-            callback(null, "EMPTY");
-            return;
-        }
-        if (url.substring(0, 3).toUpperCase() == "WOL") {
-            //Wake on lan request
-            var macAddress = url.replace(/^WOL[:]?[\/]?[\/]?/ig, "");
-            this.log("Excuting WakeOnLan request to " + macAddress);
-            wol.wake(macAddress, function(error) {
-                if (error) {
-                    callback(error);
-                } else {
-                    callback(null, "OK");
-                }
-            });
-        } else {
-            if (url.length > 3) {
-                callback(new Error("Unsupported protocol: ", "ERROR"));
-            } else {
-                callback(null, "EMPTY");
-            }
-        }
-    },
+	wolRequest: function(url, callback) {
+		this.log('calling WOL with URL %s', url);
+		if (!url) {
+			callback(null, "EMPTY");
+			return;
+		}
+		if (url.substring(0, 3).toUpperCase() == "WOL") {
+			//Wake on lan request
+			var macAddress = url.replace(/^WOL[:]?[\/]?[\/]?/ig, "");
+			this.log("Excuting WakeOnLan request to " + macAddress);
+			wol.wake(macAddress, function(error) {
+				if (error) {
+					callback(error);
+				} else {
+					callback(null, "OK");
+				}
+			});
+		} else {
+			if (url.length > 3) {
+				callback(new Error("Unsupported protocol: ", "ERROR"));
+			} else {
+				callback(null, "EMPTY");
+			}
+		}
+	},
 
-    // POWER FUNCTIONS
-    setPowerStateLoop: function(nCount, url, body, powerState, callback) {
-        var that = this;
+	// POWER FUNCTIONS
+	setPowerStateLoop: function(nCount, url, body, powerState, callback) {
+		var that = this;
 
-        that.httpRequest(url, body, "POST", this.need_authentication, function(error, response, responseBody) {
-            if (error) {
-                if (nCount > 0) {
-                    that.log('setPowerStateLoop - powerstate attempt, attempt id: ', nCount - 1);
-                    that.setPowerStateLoop(nCount - 1, url, body, powerState, function(err, state_power) {
-                        callback(err, state_power);
-                    });
-                } else {
-                    that.log('setPowerStateLoop - failed: %s', error.message);
-                    powerState = false;
-                    callback(new Error("HTTP attempt failed"), powerState);
-                }
-            } else {
-                that.log('setPowerStateLoop - Succeeded - current state: %s', powerState);
-                callback(null, powerState);
-            }
-        });
-    },
+		that.httpRequest(url, body, "POST", this.need_authentication, function(error, response, responseBody) {
+			if (error) {
+				if (nCount > 0) {
+					that.log('setPowerStateLoop - powerstate attempt, attempt id: ', nCount - 1);
+					that.setPowerStateLoop(nCount - 1, url, body, powerState, function(err, state_power) {
+						callback(err, state_power);
+					});
+				} else {
+					that.log('setPowerStateLoop - failed: %s', error.message);
+					powerState = false;
+					callback(new Error("HTTP attempt failed"), powerState);
+				}
+			} else {
+				that.log('setPowerStateLoop - Succeeded - current state: %s', powerState);
+				callback(null, powerState);
+			}
+		});
+	},
 
-    setPowerState: function(powerState, callback, context) {
-        var url = this.power_url;
-        var body;
-        var that = this;
+	setPowerState: function(powerState, callback, context) {
+		var url = this.power_url;
+		var body;
+		var that = this;
 
 		this.log.debug("Entering %s with context: %s and target value: %s", arguments.callee.name, context, powerState);
 
-        if (context && context == "statuspoll") {
+		if (context && context == "statuspoll") {
 				callback(null, powerState);
 				return;
-        }
+		}
 
-        this.set_attempt = this.set_attempt + 1;
+		this.set_attempt = this.set_attempt + 1;
 
-        if (powerState) {
-            if (this.model_year_nr <= 2013) {
-                this.log("Power On is not possible for model_year before 2014.");
-                callback(new Error("Power On is not possible for model_year before 2014."));
-            }
-            body = this.power_on_body;
-            this.log("setPowerState - Will power on");
+		if (powerState) {
+			if (this.model_year_nr <= 2013) {
+				this.log("Power On is not possible for model_year before 2014.");
+				callback(new Error("Power On is not possible for model_year before 2014."));
+			}
+			body = this.power_on_body;
+			this.log("setPowerState - Will power on");
 			// If Mac Addr for WOL is set
 			if (this.wol_url) {
 				that.log('setPowerState - Sending WOL');
@@ -337,508 +332,608 @@ HttpStatusAccessory.prototype = {
 					});
 				}.bind(this));
 			} 
-        } else {
-            body = this.power_off_body;
-            this.log("setPowerState - Will power off");
-            that.setPowerStateLoop(0, url, body, powerState, function(error, state_power) {
-                that.state_power = state_power;
-                if (error) {
-                    that.state_power = false;
-                    that.log("setPowerStateLoop - ERROR: %s", error);
-                }
-                if (that.switchService) {
-                    that.switchService.getCharacteristic(Characteristic.On).setValue(that.state_power, null, "statuspoll");
-                }
-                if (that.ambilightService) {
-                    that.state_ambilight = false;
-                    that.ambilightService.getCharacteristic(Characteristic.On).setValue(that.state_ambilight, null, "statuspoll");
-                }
-                 if (that.volumeService) {
-                    that.state_volume = false;
-                    that.volumeService.getCharacteristic(Characteristic.On).setValue(that.state_volume, null, "statuspoll");
-                }
-                callback(error, that.state_power);
-            }.bind(this));
-        }
-    },
+		} else {
+			body = this.power_off_body;
+			this.log("setPowerState - Will power off");
+			that.setPowerStateLoop(0, url, body, powerState, function(error, state_power) {
+				that.state_power = state_power;
+				if (error) {
+					that.state_power = false;
+					that.log("setPowerStateLoop - ERROR: %s", error);
+				}
+				if (that.switchService) {
+					that.switchService.getCharacteristic(Characteristic.On).setValue(that.state_power, null, "statuspoll");
+				}
+				if (that.ambilightService) {
+					that.state_ambilight = false;
+					that.ambilightService.getCharacteristic(Characteristic.On).setValue(that.state_ambilight, null, "statuspoll");
+				}
+				 if (that.volumeService) {
+					that.state_volume = false;
+					that.volumeService.getCharacteristic(Characteristic.On).setValue(that.state_volume, null, "statuspoll");
+				}
+				callback(error, that.state_power);
+			}.bind(this));
+		}
+	},
 
-    getPowerState: function(callback, context) {
-        var that = this;
-        var url = this.power_url;
-        
-        
-   		this.log.debug("Entering %s with context: %s and current value: %s", arguments.callee.name, context, this.state_power);
-        //if context is statuspoll, then we need to request the actual value else we return the cached value
+	getPowerState: function(callback, context) {
+		var that = this;
+		var url = this.power_url;
+		
+		
+		this.log.debug("Entering %s with context: %s and current value: %s", arguments.callee.name, context, this.state_power);
+		//if context is statuspoll, then we need to request the actual value else we return the cached value
 		if ((!context || context != "statuspoll") && this.switchHandling == "poll") {
-            callback(null, this.state_power);
-            return;
-        }
+			callback(null, this.state_power);
+			return;
+		}
 
-        this.httpRequest(url, "", "GET", this.need_authentication, function(error, response, responseBody) {
-            var tResp = that.state_power;
-            var fctname = "getPowerState";
-            if (error) {
-                that.log('%s - ERROR: %s', fctname, error.message);
-                that.state_power = false;
-            } else {
-                if (responseBody) {
-                    var responseBodyParsed;
-                    try {
-                        responseBodyParsed = JSON.parse(responseBody);
-                        if (responseBodyParsed && responseBodyParsed.powerstate) {
-                        	tResp = (responseBodyParsed.powerstate == "On") ? 1 : 0;
+		this.httpRequest(url, "", "GET", this.need_authentication, function(error, response, responseBody) {
+			var tResp = that.state_power;
+			var fctname = "getPowerState";
+			if (error) {
+				that.log('%s - ERROR: %s', fctname, error.message);
+				that.state_power = false;
+			} else {
+				if (responseBody) {
+					var responseBodyParsed;
+					try {
+						responseBodyParsed = JSON.parse(responseBody);
+						if (responseBodyParsed && responseBodyParsed.powerstate) {
+							tResp = (responseBodyParsed.powerstate == "On") ? 1 : 0;
 						} else {
-		                    that.log("%s - Could not parse message: '%s', not updating state", fctname, responseBody);
+							that.log("%s - Could not parse message: '%s', not updating state", fctname, responseBody);
 						}
-                    } catch (e) {
-                        that.log("%s - Got non JSON answer - not updating state: '%s'", fctname, responseBody);
-                    }
-                }
-                if (that.state_power != tResp) {
-                    that.log('%s - Level changed to: %s', fctname, tResp);
-	                that.state_power = tResp;
-                }
-            }
-            callback(null, that.state_power);
-        }.bind(this));
-    },
+					} catch (e) {
+						that.log("%s - Got non JSON answer - not updating state: '%s'", fctname, responseBody);
+					}
+				}
+				if (that.state_power != tResp) {
+					that.log('%s - Level changed to: %s', fctname, tResp);
+					that.state_power = tResp;
+				}
+			}
+			callback(null, that.state_power);
+		}.bind(this));
+	},
 
-    // AMBILIGHT FUNCTIONS
-    setAmbilightStateLoop: function(nCount, url, body, ambilightState, callback) {
-        var that = this;
+	// AMBILIGHT FUNCTIONS
+	setAmbilightStateLoop: function(nCount, url, body, ambilightState, callback) {
+		var that = this;
 
-        that.httpRequest(url, body, "POST", this.need_authentication, function(error, response, responseBody) {
-            if (error) {
-                if (nCount > 0) {
-                    that.log('setAmbilightStateLoop - attempt, attempt id: ', nCount - 1);
-                    that.setAmbilightStateLoop(nCount - 1, url, body, ambilightState, function(err, state) {
-                        callback(err, state);
-                    });
-                } else {
-                    that.log('setAmbilightStateLoop - failed: %s', error.message);
-                    ambilightState = false;
-                    callback(new Error("HTTP attempt failed"), ambilightState);
-                }
-            } else {
-                that.log('setAmbilightStateLoop - succeeded - current state: %s', ambilightState);
-                callback(null, ambilightState);
-            }
-        });
-    },
+		that.httpRequest(url, body, "POST", this.need_authentication, function(error, response, responseBody) {
+			if (error) {
+				if (nCount > 0) {
+					that.log('setAmbilightStateLoop - attempt, attempt id: ', nCount - 1);
+					that.setAmbilightStateLoop(nCount - 1, url, body, ambilightState, function(err, state) {
+						callback(err, state);
+					});
+				} else {
+					that.log('setAmbilightStateLoop - failed: %s', error.message);
+					ambilightState = false;
+					callback(new Error("HTTP attempt failed"), ambilightState);
+				}
+			} else {
+				that.log('setAmbilightStateLoop - succeeded - current state: %s', ambilightState);
+				callback(null, ambilightState);
+			}
+		});
+	},
 
-    setAmbilightState: function(ambilightState, callback, context) {
+	setAmbilightState: function(ambilightState, callback, context) {
 		this.log.debug("Entering setAmbilightState with context: %s and requested value: %s", context, ambilightState);
-        var url;
-        var body;
-        var that = this;
+		var url;
+		var body;
+		var that = this;
 
-        //if context is statuspoll, then we need to ensure that we do not set the actual value
-        if (context && context == "statuspoll") {
-            callback(null, ambilightState);
-            return;
-        }
+		//if context is statuspoll, then we need to ensure that we do not set the actual value
+		if (context && context == "statuspoll") {
+			callback(null, ambilightState);
+			return;
+		}
 
-        this.set_attempt = this.set_attempt + 1;
+		this.set_attempt = this.set_attempt + 1;
 
-        if (ambilightState) {
-            url = this.ambilight_config_url;
-            body = this.ambilight_power_on_body;
-            this.log("setAmbilightState - setting state to on");
-        } else {
-            url = this.ambilight_config_url;
-            body = this.ambilight_power_off_body;
-            this.log("setAmbilightState - setting state to off");
-        }
+		if (ambilightState) {
+			url = this.ambilight_config_url;
+			body = this.ambilight_power_on_body;
+			this.log("setAmbilightState - setting state to on");
+		} else {
+			url = this.ambilight_config_url;
+			body = this.ambilight_power_off_body;
+			this.log("setAmbilightState - setting state to off");
+		}
 
-        that.setAmbilightStateLoop(0, url, body, ambilightState, function(error, state) {
-            that.state_ambilight = ambilightState;
-            if (error) {
-                that.state_ambilight = false;
-                that.log("setAmbilightState - ERROR: %s", error);
-                if (that.ambilightService) {
-                    that.ambilightService.getCharacteristic(Characteristic.On).setValue(that.state_ambilight, null, "statuspoll");
-                }
-            }
-            callback(error, that.state_ambilight);
-        }.bind(this));
-    },
+		that.setAmbilightStateLoop(0, url, body, ambilightState, function(error, state) {
+			that.state_ambilight = ambilightState;
+			if (error) {
+				that.state_ambilight = false;
+				that.log("setAmbilightState - ERROR: %s", error);
+				if (that.ambilightService) {
+					that.ambilightService.getCharacteristic(Characteristic.On).setValue(that.state_ambilight, null, "statuspoll");
+				}
+			}
+			callback(error, that.state_ambilight);
+		}.bind(this));
+	},
 
-    getAmbilightState: function(callback, context) {
-        var that = this;
-        var url = this.ambilight_status_url;
-        var body = this.ambilight_mode_body;
+	getAmbilightState: function(callback, context) {
+		var that = this;
+		var url = this.ambilight_status_url;
+		var body = this.ambilight_mode_body;
 
 		this.log.debug("Entering %s with context: %s and current value: %s", arguments.callee.name, context, this.state_ambilight);
-        //if context is statuspoll, then we need to request the actual value
+		//if context is statuspoll, then we need to request the actual value
 		if ((!context || context != "statuspoll") && this.switchHandling == "poll") {
-            callback(null, this.state_ambilight);
-            return;
-        }
-        if (!this.state_power) {
-                callback(null, false);
-                return;
-        }
+			callback(null, this.state_ambilight);
+			return;
+		}
+		if (!this.state_power) {
+				callback(null, false);
+				return;
+		}
 
-        this.httpRequest(url, body, "POST", this.need_authentication, function(error, response, responseBody) {
-            var tResp = that.state_ambilight;
-            var fctname = "getAmbilightState";
-            if (error) {
-                that.log('%s - ERROR: %s', fctname, error.message);
-            } else {
-                if (responseBody) {
-	                var responseBodyParsed;
-                    try {
+		this.httpRequest(url, body, "POST", this.need_authentication, function(error, response, responseBody) {
+			var tResp = that.state_ambilight;
+			var fctname = "getAmbilightState";
+			if (error) {
+				that.log('%s - ERROR: %s', fctname, error.message);
+			} else {
+				if (responseBody) {
+					var responseBodyParsed;
+					try {
 						responseBodyParsed = JSON.parse(responseBody);
 						if (responseBodyParsed && responseBodyParsed.values[0].value.data.activenode_id) {
 							tResp = (responseBodyParsed.values[0].value.data.activenode_id == 110) ? false : true;
 							that.log.debug('%s - got answer %s', fctname, tResp);
 						} else {
-		                    that.log("%s - Could not parse message: '%s', not updating state", fctname, responseBody);
+							that.log("%s - Could not parse message: '%s', not updating state", fctname, responseBody);
 						}
 					} catch (e) {
-                        that.log("%s - Got non JSON answer - not updating state: '%s'", fctname, responseBody);
-                    }
-                }
-                if (that.state_ambilight != tResp) {
-                    that.log('%s - state changed to: %s', fctname, tResp);
-	                that.state_ambilight = tResp;
-                }
-            }
-            callback(null, that.state_ambilight);
-        }.bind(this));
-    },
+						that.log("%s - Got non JSON answer - not updating state: '%s'", fctname, responseBody);
+					}
+				}
+				if (that.state_ambilight != tResp) {
+					that.log('%s - state changed to: %s', fctname, tResp);
+					that.state_ambilight = tResp;
+				}
+			}
+			callback(null, that.state_ambilight);
+		}.bind(this));
+	},
 
-    setAmbilightBrightnessLoop: function(nCount, url, body, ambilightLevel, callback) {
-        var that = this;
+	setAmbilightBrightnessLoop: function(nCount, url, body, ambilightLevel, callback) {
+		var that = this;
 
-        that.httpRequest(url, body, "POST", this.need_authentication, function(error, response, responseBody) {
-            if (error) {
-                if (nCount > 0) {
-                    that.log('setAmbilightStateLoop - attempt, attempt id: ', nCount - 1);
-                    that.setAmbilightBrightnessLoop(nCount - 1, url, body, ambilightLevel, function(err, state) {
-                        callback(err, state);
-                    });
-                } else {
-                    that.log('setAmbilightBrightnessLoop - failed: %s', error.message);
-                    ambilightLevel = false;
-                    callback(new Error("HTTP attempt failed"), ambilightLevel);
-                }
-            } else {
-                that.log('setAmbilightBrightnessLoop - succeeded - current state: %s', ambilightLevel);
-                callback(null, ambilightLevel);
-            }
-        });
-    },
+		that.httpRequest(url, body, "POST", this.need_authentication, function(error, response, responseBody) {
+			if (error) {
+				if (nCount > 0) {
+					that.log('setAmbilightStateLoop - attempt, attempt id: ', nCount - 1);
+					that.setAmbilightBrightnessLoop(nCount - 1, url, body, ambilightLevel, function(err, state) {
+						callback(err, state);
+					});
+				} else {
+					that.log('setAmbilightBrightnessLoop - failed: %s', error.message);
+					ambilightLevel = false;
+					callback(new Error("HTTP attempt failed"), ambilightLevel);
+				}
+			} else {
+				that.log('setAmbilightBrightnessLoop - succeeded - current state: %s', ambilightLevel);
+				callback(null, ambilightLevel);
+			}
+		});
+	},
 
-    setAmbilightBrightness: function(ambilightLevel, callback, context) {
+	setAmbilightBrightness: function(ambilightLevel, callback, context) {
 		var TV_Adjusted_ambilightLevel = Math.round(ambilightLevel / 10);
-        var url = this.ambilight_config_url;
-        var body = JSON.stringify({"value":{"Nodeid":200,"Controllable":true,"Available":true,"data":{"value":TV_Adjusted_ambilightLevel}}});
-        var that = this;
+		var url = this.ambilight_config_url;
+		var body = JSON.stringify({"value":{"Nodeid":200,"Controllable":true,"Available":true,"data":{"value":TV_Adjusted_ambilightLevel}}});
+		var that = this;
 
- 		this.log.debug("Entering setAmbilightBrightness with context: %s and requested value: %s", context, ambilightLevel);
-        //if context is statuspoll, then we need to ensure that we do not set the actual value
-        if (context && context == "statuspoll") {
-            callback(null, ambilightLevel);
-            return;
-        }
+		this.log.debug("Entering setAmbilightBrightness with context: %s and requested value: %s", context, ambilightLevel);
+		//if context is statuspoll, then we need to ensure that we do not set the actual value
+		if (context && context == "statuspoll") {
+			callback(null, ambilightLevel);
+			return;
+		}
 
-        this.set_attempt = this.set_attempt + 1;
+		this.set_attempt = this.set_attempt + 1;
 
-        that.setAmbilightBrightnessLoop(0, url, body, ambilightLevel, function(error, state) {
-            that.state_ambilightLevel = ambilightLevel;
-            if (error) {
-                that.state_ambilightLevel = false;
-                that.log("setAmbilightBrightness - ERROR: %s", error);
-                if (that.ambilightService) {
-                    that.ambilightService.getCharacteristic(Characteristic.On).setValue(that.state_ambilightLevel, null, "statuspoll");
-                }
-            }
-            callback(error, that.state_ambilightLevel);
-        }.bind(this));
-    },
+		that.setAmbilightBrightnessLoop(0, url, body, ambilightLevel, function(error, state) {
+			that.state_ambilightLevel = ambilightLevel;
+			if (error) {
+				that.state_ambilightLevel = false;
+				that.log("setAmbilightBrightness - ERROR: %s", error);
+				if (that.ambilightService) {
+					that.ambilightService.getCharacteristic(Characteristic.On).setValue(that.state_ambilightLevel, null, "statuspoll");
+				}
+			}
+			callback(error, that.state_ambilightLevel);
+		}.bind(this));
+	},
 
-    getAmbilightBrightness: function(callback, context) {
-        var that = this;
-        var url = this.ambilight_status_url;
-        var body = this.ambilight_brightness_body;
+	getAmbilightBrightness: function(callback, context) {
+		var that = this;
+		var url = this.ambilight_status_url;
+		var body = this.ambilight_brightness_body;
 
 		this.log.debug("Entering %s with context: %s and current value: %s", arguments.callee.name, context, this.state_ambilightLevel);
-        //if context is statuspoll, then we need to request the actual value
+		//if context is statuspoll, then we need to request the actual value
 		if ((!context || context != "statuspoll") && this.switchHandling == "poll") {
-            callback(null, this.state_ambilightLevel);
-            return;
-        }
-        if (!this.state_power) {
-                callback(null, 0);
-                return;
-        }
+			callback(null, this.state_ambilightLevel);
+			return;
+		}
+		if (!this.state_power) {
+				callback(null, 0);
+				return;
+		}
 
-        this.httpRequest(url, body, "POST", this.need_authentication, function(error, response, responseBody) {
-            var tResp = that.state_ambilightLevel;
-            var fctname = "getAmbilightBrightness";
-            if (error) {
-                that.log('%s - ERROR: %s', fctname, error.message);
-            } else {
-                if (responseBody) {
-	                var responseBodyParsed;
-                    try {
+		this.httpRequest(url, body, "POST", this.need_authentication, function(error, response, responseBody) {
+			var tResp = that.state_ambilightLevel;
+			var fctname = "getAmbilightBrightness";
+			if (error) {
+				that.log('%s - ERROR: %s', fctname, error.message);
+			} else {
+				if (responseBody) {
+					var responseBodyParsed;
+					try {
 						responseBodyParsed = JSON.parse(responseBody);
 						if (responseBodyParsed && responseBodyParsed.values[0].value.data) {
 							tResp = 10*responseBodyParsed.values[0].value.data.value;
 							that.log.debug('%s - got answer %s', fctname, tResp);
 						} else {
-		                    that.log("%s - Could not parse message: '%s', not updating level", fctname, responseBody);
+							that.log("%s - Could not parse message: '%s', not updating level", fctname, responseBody);
 						}
 					} catch (e) {
-                        that.log("%s - Got non JSON answer - not updating level: '%s'", fctname, responseBody);
-                    }
-                }
-                if (that.state_ambilightLevel != tResp) {
-                    that.log('%s - Level changed to: %s', fctname, tResp);
-	                that.state_ambilightLevel = tResp;
-                }
-            }
-            callback(null, that.state_ambilightLevel);
-        }.bind(this));
-    },
+						that.log("%s - Got non JSON answer - not updating level: '%s'", fctname, responseBody);
+					}
+				}
+				if (that.state_ambilightLevel != tResp) {
+					that.log('%s - Level changed to: %s', fctname, tResp);
+					that.state_ambilightLevel = tResp;
+				}
+			}
+			callback(null, that.state_ambilightLevel);
+		}.bind(this));
+	},
 
-    // Volume
+	// Volume
 
-    setVolumeStateLoop: function(nCount, url, body, volumeState, callback) {
-        var that = this;
+	setVolumeStateLoop: function(nCount, url, body, volumeState, callback) {
+		var that = this;
 
-        that.httpRequest(url, body, "POST", this.need_authentication, function(error, response, responseBody) {
-            if (error) {
-                if (nCount > 0) {
-                    that.log('setVolumeStateLoop - attempt, attempt id: ', nCount - 1);
-                    that.setVolumeStateLoop(nCount - 1, url, body, volumeState, function(err, state) {
-                        callback(err, state);
-                    });
-                } else {
-                    that.log('setVolumeStateLoop - failed: %s', error.message);
-                    volumeState = false;
-                    callback(new Error("HTTP attempt failed"), volumeState);
-                }
-            } else {
-                that.log('setVolumeStateLoop - succeeded - current state: %s', volumeState);
-                callback(null, volumeState);
-            }
-        });
-    },
+		that.httpRequest(url, body, "POST", this.need_authentication, function(error, response, responseBody) {
+			if (error) {
+				if (nCount > 0) {
+					that.log('setVolumeStateLoop - attempt, attempt id: ', nCount - 1);
+					that.setVolumeStateLoop(nCount - 1, url, body, volumeState, function(err, state) {
+						callback(err, state);
+					});
+				} else {
+					that.log('setVolumeStateLoop - failed: %s', error.message);
+					volumeState = false;
+					callback(new Error("HTTP attempt failed"), volumeState);
+				}
+			} else {
+				that.log('setVolumeStateLoop - succeeded - current state: %s', volumeState);
+				callback(null, volumeState);
+			}
+		});
+	},
 
-    setVolumeState: function(volumeState, callback, context) {
-        var url = this.audio_url;
-        var body;
-        var that = this;
+	setVolumeState: function(volumeState, callback, context) {
+		var url = this.audio_url;
+		var body;
+		var that = this;
 
 		this.log.debug("Entering %s with context: %s and target value: %s", arguments.callee.name, context, volumeState);
 
-        //if context is statuspoll, then we need to ensure that we do not set the actual value
-        if (context && context == "statuspoll") {
-            callback(null, volumeState);
-            return;
-        }
+		//if context is statuspoll, then we need to ensure that we do not set the actual value
+		if (context && context == "statuspoll") {
+			callback(null, volumeState);
+			return;
+		}
 
-        this.set_attempt = this.set_attempt + 1;
+		this.set_attempt = this.set_attempt + 1;
 
-        if (volumeState) {
-            body = this.audio_unmute_body;
-            this.log("setVolumeState - setting state to on");
-        } else {
-            body = this.audio_mute_body;
-            this.log("setVolumeState - setting state to off");
-        }
+		if (volumeState) {
+			body = this.audio_unmute_body;
+			this.log("setVolumeState - setting state to on");
+		} else {
+			body = this.audio_mute_body;
+			this.log("setVolumeState - setting state to off");
+		}
 
-        that.setVolumeStateLoop(0, url, body, volumeState, function(error, state) {
-            that.state_volume = volumeState;
-            if (error) {
-                that.state_volume = false;
-                that.log("setVolumeState - ERROR: %s", error);
-                if (that.volumeService) {
-                    that.volumeService.getCharacteristic(Characteristic.On).setValue(that.state_volume, null, "statuspoll");
-                }
-            }
-            callback(error, that.state_volume);
+		that.setVolumeStateLoop(0, url, body, volumeState, function(error, state) {
+			that.state_volume = volumeState;
+			if (error) {
+				that.state_volume = false;
+				that.log("setVolumeState - ERROR: %s", error);
+				if (that.volumeService) {
+					that.volumeService.getCharacteristic(Characteristic.On).setValue(that.state_volume, null, "statuspoll");
+				}
+			}
+			callback(error, that.state_volume);
 
-        }.bind(this));
-    },
+		}.bind(this));
+	},
 
-    setVolumeLevelLoop: function(nCount, url, body, volumeLevel, callback) {
-        var that = this;
+	setVolumeLevelLoop: function(nCount, url, body, volumeLevel, callback) {
+		var that = this;
 
-        that.httpRequest(url, body, "POST", this.need_authentication, function(error, response, responseBody) {
-            if (error) {
-                if (nCount > 0) {
-                    that.log('setVolumeLevelLoop - attempt, attempt id: ', nCount - 1);
-                    that.setVolumeLevelLoop(nCount - 1, url, body, volumeLevel, function(err, state) {
-                        callback(err, state);
-                    });
-                } else {
-                    that.log('setVolumeLevelLoop - failed: %s', error.message);
-                    volumeLevel = false;
-                    callback(new Error("HTTP attempt failed"), volumeLevel);
-                }
-            } else {
-                that.log('setVolumeLevelLoop - succeeded - current level: %s', volumeLevel);
-                callback(null, volumeLevel);
-            }
-        });
-    },
+		that.httpRequest(url, body, "POST", this.need_authentication, function(error, response, responseBody) {
+			if (error) {
+				if (nCount > 0) {
+					that.log('setVolumeLevelLoop - attempt, attempt id: ', nCount - 1);
+					that.setVolumeLevelLoop(nCount - 1, url, body, volumeLevel, function(err, state) {
+						callback(err, state);
+					});
+				} else {
+					that.log('setVolumeLevelLoop - failed: %s', error.message);
+					volumeLevel = false;
+					callback(new Error("HTTP attempt failed"), volumeLevel);
+				}
+			} else {
+				that.log('setVolumeLevelLoop - succeeded - current level: %s', volumeLevel);
+				callback(null, volumeLevel);
+			}
+		});
+	},
 
-    setVolumeLevel: function(volumeLevel, callback, context) {
-        var TV_Adjusted_volumeLevel = Math.round(volumeLevel / 4);
-        var url = this.audio_url;
-        var body = JSON.stringify({"current": TV_Adjusted_volumeLevel});
-        var that = this;
+	setVolumeLevel: function(volumeLevel, callback, context) {
+		var TV_Adjusted_volumeLevel = Math.round(volumeLevel / 4);
+		var url = this.audio_url;
+		var body = JSON.stringify({"current": TV_Adjusted_volumeLevel});
+		var that = this;
 
 		this.log.debug("Entering %s with context: %s and target value: %s", arguments.callee.name, context, volumeLevel);
 
-        //if context is statuspoll, then we need to ensure that we do not set the actual value
-        if (context && context == "statuspoll") {
-            callback(null, volumeLevel);
-            return;
-        }
+		//if context is statuspoll, then we need to ensure that we do not set the actual value
+		if (context && context == "statuspoll") {
+			callback(null, volumeLevel);
+			return;
+		}
 
-        this.set_attempt = this.set_attempt + 1;
+		this.set_attempt = this.set_attempt + 1;
 
-        // volumeLevel will be in %, let's convert to reasonable values accepted by TV
-        that.setVolumeLevelLoop(0, url, body, volumeLevel, function(error, state) {
-            that.state_volumeLevel = volumeLevel;
-            if (error) {
-                that.state_volumeLevel = false;
-                that.log("setVolumeState - ERROR: %s", error);
-                if (that.volumeService) {
-                    that.volumeService.getCharacteristic(Characteristic.On).setValue(that.state_volumeLevel, null, "statuspoll");
-                }
-            }
-            callback(error, that.state_volumeLevel);
-        }.bind(this));
-    },
+		// volumeLevel will be in %, let's convert to reasonable values accepted by TV
+		that.setVolumeLevelLoop(0, url, body, volumeLevel, function(error, state) {
+			that.state_volumeLevel = volumeLevel;
+			if (error) {
+				that.state_volumeLevel = false;
+				that.log("setVolumeState - ERROR: %s", error);
+				if (that.volumeService) {
+					that.volumeService.getCharacteristic(Characteristic.On).setValue(that.state_volumeLevel, null, "statuspoll");
+				}
+			}
+			callback(error, that.state_volumeLevel);
+		}.bind(this));
+	},
 
-    getVolumeState: function(callback, context) {
-        var that = this;
-        var url = this.audio_url;
+	getVolumeState: function(callback, context) {
+		var that = this;
+		var url = this.audio_url;
 
-   		this.log.debug("Entering %s with context: %s and current state: %s", arguments.callee.name, context, this.state_volume);
+		this.log.debug("Entering %s with context: %s and current state: %s", arguments.callee.name, context, this.state_volume);
 
-        //if context is statuspoll, then we need to request the actual value
+		//if context is statuspoll, then we need to request the actual value
 		if ((!context || context != "statuspoll") && this.switchHandling == "poll") {
-            callback(null, this.state_volume);
-            return;
-        }
-        if (!this.state_power) {
-                callback(null, false);
-                return;
-        }
-        
-        this.httpRequest(url, "", "GET", this.need_authentication, function(error, response, responseBody) {
-            var tResp = that.state_volume;
-            var fctname = "getVolumeState";
-            if (error) {
-                that.log('%s - ERROR: %s', fctname, error.message);
-            } else {
-                if (responseBody) {
-                	var responseBodyParsed;
-                    try {
+			callback(null, this.state_volume);
+			return;
+		}
+		if (!this.state_power) {
+				callback(null, false);
+				return;
+		}
+		
+		this.httpRequest(url, "", "GET", this.need_authentication, function(error, response, responseBody) {
+			var tResp = that.state_volume;
+			var fctname = "getVolumeState";
+			if (error) {
+				that.log('%s - ERROR: %s', fctname, error.message);
+			} else {
+				if (responseBody) {
+					var responseBodyParsed;
+					try {
 						responseBodyParsed = JSON.parse(responseBody);
 						if (responseBodyParsed) {
 							tResp = (responseBodyParsed.muted == "true") ? 0 : 1;
 							that.log.debug('%s - got answer %s', fctname, tResp);
 						} else {
-		                    that.log("%s - Could not parse message: '%s', not updating state", fctname, responseBody);
+							that.log("%s - Could not parse message: '%s', not updating state", fctname, responseBody);
 						}
 					} catch (e) {
-                        that.log("%s - Got non JSON answer - not updating state: '%s'", fctname, responseBody);
-                    }
-                }
-                if (that.state_volume != tResp) {
-                    that.log('%s - state changed to: %s', fctname, tResp);
-	                that.state_volume = tResp;
-                }
-            }
-            callback(null, tResp);
-        }.bind(this));
-    },
+						that.log("%s - Got non JSON answer - not updating state: '%s'", fctname, responseBody);
+					}
+				}
+				if (that.state_volume != tResp) {
+					that.log('%s - state changed to: %s', fctname, tResp);
+					that.state_volume = tResp;
+				}
+			}
+			callback(null, tResp);
+		}.bind(this));
+	},
 
-    getVolumeLevel: function(callback, context) {
-        var that = this;
-        var url = this.audio_url;
+	getVolumeLevel: function(callback, context) {
+		var that = this;
+		var url = this.audio_url;
 
-   		this.log.debug("Entering %s with context: %s and current value: %s", arguments.callee.name, context, this.state_volumeLevel);
-        //if context is statuspoll, then we need to request the actual value
+		this.log.debug("Entering %s with context: %s and current value: %s", arguments.callee.name, context, this.state_volumeLevel);
+		//if context is statuspoll, then we need to request the actual value
 		if ((!context || context != "statuspoll") && this.switchHandling == "poll") {
-            callback(null, this.state_volumeLevel);
-            return;
-        }
-        if (!this.state_power) {
-                callback(null, 0);
-                return;
-        }
+			callback(null, this.state_volumeLevel);
+			return;
+		}
+		if (!this.state_power) {
+				callback(null, 0);
+				return;
+		}
 
-        this.httpRequest(url, "", "GET", this.need_authentication, function(error, response, responseBody) {
-            var tResp = that.state_volumeLevel;
-            var fctname = "getVolumeLevel";
-            if (error) {
-                that.log('%s - ERROR: %s', fctname, error.message);
-            } else {
-                if (responseBody) {
-                    var responseBodyParsed;
-                    try {
+		this.httpRequest(url, "", "GET", this.need_authentication, function(error, response, responseBody) {
+			var tResp = that.state_volumeLevel;
+			var fctname = "getVolumeLevel";
+			if (error) {
+				that.log('%s - ERROR: %s', fctname, error.message);
+			} else {
+				if (responseBody) {
+					var responseBodyParsed;
+					try {
 						responseBodyParsed = JSON.parse(responseBody);
 						if (responseBodyParsed) {
 							tResp = Math.round(4 * responseBodyParsed.current);
 							that.log.debug('%s - got answer %s', fctname, tResp);
 						} else {
-		                    that.log("%s - Could not parse message: '%s', not updating level", fctname, responseBody);
+							that.log("%s - Could not parse message: '%s', not updating level", fctname, responseBody);
 						}
 					 } catch (e) {
-                        that.log("%s - Got non JSON answer - not updating level: '%s'", fctname, responseBody);
-                    }
-                }
-				if (that.state_volumeLevel != tResp) {
-                    that.log('%s - Level changed to: %s', fctname, tResp);
-	                that.state_volumeLevel = tResp;
+						that.log("%s - Got non JSON answer - not updating level: '%s'", fctname, responseBody);
+					}
 				}
-            }
-            callback(null, that.state_volumeLevel);
-        }.bind(this));
-    },
+				if (that.state_volumeLevel != tResp) {
+					that.log('%s - Level changed to: %s', fctname, tResp);
+					that.state_volumeLevel = tResp;
+				}
+			}
+			callback(null, that.state_volumeLevel);
+		}.bind(this));
+	},
 
-    /// Next input
-    setNextInput: function(inputState, callback, context) {
-        this.log.debug("Entering %s with context: %s and target value: %s", arguments.callee.name, context, inputState);
+	pressRemoteButton: function(remoteKey, callback, context) {
+		this.log.debug("Entering %s with context: %s and target value: %s", arguments.callee.name, context, remoteKey);
 
-        url = this.input_url;
-        body = JSON.stringify({"key": "Source"});
-        this.httpRequest(url, body, "POST", this.need_authentication, function(error, response, responseBody) {
-            if (error) {
-                this.log('setNextInput - error: ', error.message);
-            } else {
-                	this.log('Source - succeeded - current state: %s', inputState);
+		var button = "";
+		switch (remoteKey) {
+		case Characteristic.RemoteKey.REWIND:
+			button = "Rewind";
+			break;
+		case Characteristic.RemoteKey.FAST_FORWARD:
+			button = "FastForward";
+			break;
+		case Characteristic.RemoteKey.NEXT_TRACK:
+			button = "Next";
+			break;
+		case Characteristic.RemoteKey.PREVIOUS_TRACK:
+			button = "Previous";
+			break;
+		case Characteristic.RemoteKey.ARROW_UP:
+			button = "CursorUp";
+			break;
+		case Characteristic.RemoteKey.ARROW_DOWN:
+			button = "CursorDown";
+			break;
+		case Characteristic.RemoteKey.ARROW_LEFT:
+			button = "CursorLeft";
+			break;
+		case Characteristic.RemoteKey.ARROW_RIGHT:
+			button = "CursorRight";
+			break;
+		case Characteristic.RemoteKey.SELECT:
+			button = "Confirm";
+			break;
+		case Characteristic.RemoteKey.BACK:
+			button = "Back";
+			break;
+		case Characteristic.RemoteKey.EXIT:
+			button = "Exit";
+			break;
+		case Characteristic.RemoteKey.PLAY_PAUSE:
+			button = this.playpause_button || "PlayPause";
+			break;
+		case Characteristic.RemoteKey.INFORMATION:
+			button = this.info_button || "Options";
+			break;
+		default:
+			this.log("Unknown remote key: %s", remoteKey);
+			button = "";
+			break;
+		}
+		if (button != "") {
+			url = this.input_url;
+			body = JSON.stringify({ "key": button });
+			this.log.debug("Sending button: %s", body);
+			this.httpRequest(url, body, "POST", this.need_authentication, function(error, response, responseBody) {
+				if (error) {
+					this.log('pressRemoteButton - error: ', error.message);
+                }
+			}.bind(this));
+		}
+		callback(null, null);
+	},
+
+	pressMenuButton: function(state, callback, context) {
+		this.log.debug("Entering %s with context: %s and target value: %s", arguments.callee.name, context, state);
+		url = this.input_url;
+		body = JSON.stringify({ "key": "Options" });
+		this.httpRequest(url, body, "POST", this.need_authentication, function(error, response, responseBody) {
+			if (error) {
+				this.log('pressMenuButton - error: ', error.message);
+			}
+		}.bind(this));
+		callback(null, null);
+	},
+
+	pressVolumeButton: function(state, callback, context) {
+		this.log.debug("Entering %s with context: %s and target value: %s", arguments.callee.name, context, state);
+		url = this.input_url;
+		body = JSON.stringify({ "key": (state ? "VolumeDown" : "VolumeUp") });
+		this.httpRequest(url, body, "POST", this.need_authentication, function(error, response, responseBody) {
+			if (error) {
+				this.log('pressVolumeButton - error: ', error.message);
+			}
+		}.bind(this));
+		callback(null, null);
+	},
+
+	getInputSource: function(callback, context) {
+		callback(null, 2);
+	},
+
+	setInputSource: function(source, callback, context) {
+		this.log.debug("Entering %s with context: %s and target value: %s", arguments.callee.name, context, source);
+
+		if (source == 1) {
+			this.setPreviousInput(true, () => { callback(null, 2) }, context);
+		} else if (source == 3) {
+			this.setNextInput(true, () => { callback(null, 2) }, context);
+		}
+	},
+
+	/// Next input
+	setNextInput: function(inputState, callback, context) {
+		this.log.debug("Entering %s with context: %s and target value: %s", arguments.callee.name, context, inputState);
+
+		url = this.input_url;
+		body = JSON.stringify({"key": "Source"});
+		this.httpRequest(url, body, "POST", this.need_authentication, function(error, response, responseBody) {
+			if (error) {
+				this.log('setNextInput - error: ', error.message);
+			} else {
+					this.log.debug('Source - succeeded - current state: %s', inputState);
 
 					setTimeout(function () {
-					body = JSON.stringify({"key": "CursorDown"});
+					body = JSON.stringify({"key": "CursorRight"});
 
 					this.httpRequest(url, body, "POST", this.need_authentication, function(error, response, responseBody) {
 						if (error) {
-           				     this.log('setNextInput - error: ', error.message);
+							 this.log('setNextInput - error: ', error.message);
 						} else {
-								this.log('Down - succeeded - current state: %s', inputState);
+								this.log.debug('Right - succeeded - current state: %s', inputState);
 								setTimeout(function () {
-								body = JSON.stringify({"key": "CursorRight"});
+								body = JSON.stringify({"key": "CursorDown"});
 
 								this.httpRequest(url, body, "POST", this.need_authentication, function(error, response, responseBody) {
 									if (error) {
-               							 this.log('setNextInput - error: ', error.message);
+										 this.log('setNextInput - error: ', error.message);
 									} else {
-											this.log('Right - succeeded - current state: %s', inputState);
+											this.log.debug('Down - succeeded - current state: %s', inputState);
 											setTimeout(function() {
 												body = JSON.stringify({"key": "Confirm"});
 
 												this.httpRequest(url, body, "POST", this.need_authentication, function(error, response, responseBody) {
 													if (error) {
-            										    this.log('setNextInput - error: ', error.message);
+														this.log('setNextInput - error: ', error.message);
 													} else {
 															this.log.info("Source change completed");
 													}
@@ -852,49 +947,49 @@ HttpStatusAccessory.prototype = {
 					}.bind(this));
 
 				}.bind(this), 500);
-            }
-        }.bind(this));
-        callback(null, null);
-    },
+			}
+		}.bind(this));
+		callback(null, null);
+	},
 
-    getNextInput: function(callback, context) {
-        callback(null, null);
-    },
+	getNextInput: function(callback, context) {
+		callback(null, null);
+	},
 
-    /// Previous input
-    setPreviousInput: function(inputState, callback, context) {
-        this.log.debug("Entering %s with context: %s and target value: %s", arguments.callee.name, context, inputState);
+	/// Previous input
+	setPreviousInput: function(inputState, callback, context) {
+		this.log.debug("Entering %s with context: %s and target value: %s", arguments.callee.name, context, inputState);
 
-        url = this.input_url;
-        body = JSON.stringify({"key": "Source"});
-        this.httpRequest(url, body, "POST", this.need_authentication, function(error, response, responseBody) {
-            if (error) {
-                this.log('setPreviousInput - error: ', error.message);
-            } else {
-                	this.log('Source - succeeded - current state: %s', inputState);
+		url = this.input_url;
+		body = JSON.stringify({"key": "Source"});
+		this.httpRequest(url, body, "POST", this.need_authentication, function(error, response, responseBody) {
+			if (error) {
+				this.log('setPreviousInput - error: ', error.message);
+			} else {
+					this.log.debug('Source - succeeded - current state: %s', inputState);
 
 					setTimeout(function () {
-					body = JSON.stringify({"key": "CursorDown"});
+					body = JSON.stringify({"key": "CursorLeft"});
 
 					this.httpRequest(url, body, "POST", this.need_authentication, function(error, response, responseBody) {
 						if (error) {
-			                this.log('setPreviousInput - error: ', error.message);
+							this.log('setPreviousInput - error: ', error.message);
 						} else {
-								this.log('Down - succeeded - current state: %s', inputState);
+								this.log.debug('Left - succeeded - current state: %s', inputState);
 								setTimeout(function () {
-								body = JSON.stringify({"key": "CursorLeft"});
+								body = JSON.stringify({"key": "CursorUp"});
 
 								this.httpRequest(url, body, "POST", this.need_authentication, function(error, response, responseBody) {
 									if (error) {
-						                this.log('setPreviousInput - error: ', error.message);
+										this.log('setPreviousInput - error: ', error.message);
 									} else {
-											this.log('Right - succeeded - current state: %s', inputState);
+											this.log.debug('Up - succeeded - current state: %s', inputState);
 											setTimeout(function() {
 												body = JSON.stringify({"key": "Confirm"});
 												
 												this.httpRequest(url, body, "POST", this.need_authentication, function(error, response, responseBody) {
 													if (error) {
-										                this.log('setPreviousInput - error: ', error.message);
+														this.log('setPreviousInput - error: ', error.message);
 													} else {
 															this.log.info("Source change completed");
 													}
@@ -908,78 +1003,123 @@ HttpStatusAccessory.prototype = {
 					}.bind(this));
 
 				}.bind(this), 500);
-            }
-        }.bind(this));
-        callback(null, null);
-    },
+			}
+		}.bind(this));
+		callback(null, null);
+	},
 
-    getPreviousInput: function(callback, context) {
-        callback(null, null);
-    },
+	getPreviousInput: function(callback, context) {
+		callback(null, null);
+	},
 
-    identify: function(callback) {
-        this.log("Identify requested!");
-        callback(); // success
-    },
+	identify: function(callback) {
+		this.log("Identify requested!");
+		callback(); // success
+	},
 
-    getServices: function() {
-        var that = this;
+	prepareServices: function() {
+		var that = this;
 
-        var informationService = new Service.AccessoryInformation();
-        informationService
-            .setCharacteristic(Characteristic.Name, this.name)
-            .setCharacteristic(Characteristic.Manufacturer, 'Philips')
-            .setCharacteristic(Characteristic.Model, "Year " + this.model_year);
+		this.informationService = new Service.AccessoryInformation();
+		this.informationService
+			.setCharacteristic(Characteristic.Name, this.name)
+			.setCharacteristic(Characteristic.Manufacturer, 'Philips')
+			.setCharacteristic(Characteristic.Model, "Year " + this.model_year)
+			.setCharacteristic(Characteristic.SerialNumber, this.serial_number);
+		this.enabled_services.push(this.informationService);
 
-        // POWER
-        this.switchService = new Service.Switch(this.name + " Power", '0a');
-        this.switchService
-            .getCharacteristic(Characteristic.On)
-            .on('get', this.getPowerState.bind(this))
-            .on('set', this.setPowerState.bind(this));
+		this.tvService = new Service.Television(this.name, 'tvService' + this.name);
+		this.tvService
+			.setCharacteristic(Characteristic.Name, this.name)
+			.setCharacteristic(Characteristic.ConfiguredName, this.name)
+			.setCharacteristic(Characteristic.SleepDiscoveryMode, Characteristic.SleepDiscoveryMode.ALWAYS_DISCOVERABLE)
+			.setCharacteristic(Characteristic.ActiveIdentifier, -1)
+			.setCharacteristic(Characteristic.Active, false);
 
-        // Volume
-        this.volumeService = new Service.Lightbulb(this.name + " Volume", '0b');
-        this.volumeService
-            .getCharacteristic(Characteristic.On)
-            .on('get', this.getVolumeState.bind(this))
-            .on('set', this.setVolumeState.bind(this));
+		this.tvService.getCharacteristic(Characteristic.Active)
+			.on('get', this.getPowerState.bind(this))
+			.on('set', this.setPowerState.bind(this));
+		this.tvService.getCharacteristic(Characteristic.RemoteKey)
+			.on('set', this.pressRemoteButton.bind(this));
+		this.tvService.getCharacteristic(Characteristic.PowerModeSelection)
+			.on('set', this.pressMenuButton.bind(this));
+		this.enabled_services.push(this.tvService);
+		this.tvService.getCharacteristic(Characteristic.ActiveIdentifier)
+			.on('get', this.getInputSource.bind(this))
+			.on('set', this.setInputSource.bind(this));
 
-        this.volumeService
-            .getCharacteristic(Characteristic.Brightness)
-            .on('get', this.getVolumeLevel.bind(this))
-            .on('set', this.setVolumeLevel.bind(this));
+		this.speakerService = new Service.TelevisionSpeaker(this.name + ' Volume', 'tvSpeakerService');
+		this.speakerService
+			.setCharacteristic(Characteristic.Name, this.name)
+			.setCharacteristic(Characteristic.Active, Characteristic.Active.ACTIVE)
+			.setCharacteristic(Characteristic.VolumeControlType, Characteristic.VolumeControlType.ABSOLUTE);
+		this.speakerService
+			.getCharacteristic(Characteristic.Mute)
+			.on('get', this.getVolumeState.bind(this))
+			.on('set', this.setVolumeState.bind(this));
+		this.speakerService
+			.getCharacteristic(Characteristic.VolumeSelector)
+			.on('set', this.pressVolumeButton.bind(this));
+		this.speakerService
+			.addCharacteristic(Characteristic.Volume)
+			.on('get', this.getVolumeLevel.bind(this))
+			.on('set', this.setVolumeLevel.bind(this));
+		this.tvService.addLinkedService(this.speakerService);
+		this.enabled_services.push(this.speakerService);
 
-        // Previous input
-        this.PreviousInputService = new Service.Switch(this.name + " Previous input", '0c');
-        this.PreviousInputService
-            .getCharacteristic(Characteristic.On)
-            .on('get', this.getPreviousInput.bind(this))
-            .on('set', this.setPreviousInput.bind(this));
+		if (this.has_input_selector) {
+			this.previousInputSource = new Service.InputSource(this.name, this.name + ' Previous Input');
+			this.previousInputSource
+				.setCharacteristic(Characteristic.Identifier, 1)
+				.setCharacteristic(Characteristic.ConfiguredName, "Previous Input")
+				.setCharacteristic(Characteristic.InputSourceType, Characteristic.InputSourceType.APPLICATION)
+				.setCharacteristic(Characteristic.IsConfigured, Characteristic.IsConfigured.CONFIGURED);
+			this.previousInputSource.getCharacteristic(Characteristic.ConfiguredName).setProps({ perms: [Characteristic.Perms.READ] });
+			this.tvService.addLinkedService(this.previousInputSource);
 
-        // Next input
-        this.NextInputService = new Service.Switch(this.name + " Next input", '0d');
-        this.NextInputService
-            .getCharacteristic(Characteristic.On)
-            .on('get', this.getNextInput.bind(this))
-            .on('set', this.setNextInput.bind(this));
+			this.currentInputSource = new Service.InputSource(this.name, this.name + ' Input');
+			this.currentInputSource
+				.setCharacteristic(Characteristic.Identifier, 2)
+				.setCharacteristic(Characteristic.ConfiguredName, "On Input")
+				.setCharacteristic(Characteristic.InputSourceType, Characteristic.InputSourceType.APPLICATION)
+				.setCharacteristic(Characteristic.IsConfigured, Characteristic.IsConfigured.CONFIGURED);
+			this.currentInputSource.getCharacteristic(Characteristic.ConfiguredName).setProps({ perms: [Characteristic.Perms.READ] });
+			this.tvService.addLinkedService(this.currentInputSource);
 
-        if (this.has_ambilight) {
-            // AMBILIGHT
-            this.ambilightService = new Service.Lightbulb(this.name + " Ambilight", '0e');
-            this.ambilightService
-                .getCharacteristic(Characteristic.On)
-                .on('get', this.getAmbilightState.bind(this))
-                .on('set', this.setAmbilightState.bind(this));
+			this.nextInputSource = new Service.InputSource(this.name, this.name + ' Next Input');
+			this.nextInputSource
+				.setCharacteristic(Characteristic.Identifier, 3)
+				.setCharacteristic(Characteristic.ConfiguredName, "Next Input")
+				.setCharacteristic(Characteristic.InputSourceType, Characteristic.InputSourceType.APPLICATION)
+				.setCharacteristic(Characteristic.IsConfigured, Characteristic.IsConfigured.CONFIGURED);
+			this.nextInputSource.getCharacteristic(Characteristic.ConfiguredName).setProps({ perms: [Characteristic.Perms.READ] });
+			this.tvService.addLinkedService(this.nextInputSource);
 
-        	this.ambilightService
-            	.getCharacteristic(Characteristic.Brightness)
-            	.on('get', this.getAmbilightBrightness.bind(this))
-            	.on('set', this.setAmbilightBrightness.bind(this));
+			this.enabled_services.push(this.previousInputSource);
+			this.enabled_services.push(this.currentInputSource);
+			this.enabled_services.push(this.nextInputSource);
+		}
 
-            return [informationService, this.switchService, this.volumeService, this.NextInputService, this.PreviousInputService, this.ambilightService];
-        } else {
-            return [informationService, this.switchService, this.NextInputService, this.PreviousInputService, this.volumeService];
-        }
-    }
+		if (this.has_ambilight) {
+			// AMBILIGHT
+			this.ambilightService = new Service.Lightbulb(this.name + " Ambilight", '0e');
+			this.ambilightService
+				.getCharacteristic(Characteristic.On)
+				.on('get', this.getAmbilightState.bind(this))
+				.on('set', this.setAmbilightState.bind(this));
+
+			this.ambilightService
+				.getCharacteristic(Characteristic.Brightness)
+				.on('get', this.getAmbilightBrightness.bind(this))
+				.on('set', this.setAmbilightBrightness.bind(this));
+
+			this.enabled_services.push(this.ambilightService);
+		}
+
+		return this.enabled_services;
+	},
+
+	getServices: function() {
+		return this.enabled_services;
+	},
 };

--- a/index.js
+++ b/index.js
@@ -110,8 +110,8 @@ function HttpStatusAccessory(log, config) {
 
 		statusemitter.on("statuspoll_power", function(data) {
 			that.state_power = data;
-			if (that.switchService) {
-				that.switchService.getCharacteristic(Characteristic.On).setValue(that.state_power, null, "statuspoll");
+			if (that.tvService) {
+				that.tvService.getCharacteristic(Characteristic.Active).setValue(that.state_power, null, "statuspoll");
 			}
 		});
 
@@ -325,8 +325,8 @@ HttpStatusAccessory.prototype = {
 						if (error) {
 							that.state_power = false;
 							that.log("setPowerStateLoop - ERROR: %s", error);
-							if (that.switchService) {
-								that.switchService.getCharacteristic(Characteristic.On).setValue(that.state_power, null, "statuspoll");
+							if (that.tvService) {
+								that.tvService.getCharacteristic(Characteristic.Active).setValue(that.state_power, null, "statuspoll");
 							}
 						}
 					});
@@ -341,8 +341,8 @@ HttpStatusAccessory.prototype = {
 					that.state_power = false;
 					that.log("setPowerStateLoop - ERROR: %s", error);
 				}
-				if (that.switchService) {
-					that.switchService.getCharacteristic(Characteristic.On).setValue(that.state_power, null, "statuspoll");
+				if (that.tvService) {
+					that.tvService.getCharacteristic(Characteristic.Active).setValue(that.state_power, null, "statuspoll");
 				}
 				if (that.ambilightService) {
 					that.state_ambilight = false;

--- a/package.json
+++ b/package.json
@@ -1,14 +1,14 @@
 {
   "name": "homebridge-philipstv-enhanced",
-  "version": "0.2.1",
-  "description": "Homebridge module for the Philips TV (with JointSpace enabled) and ready for 2018 models",
+  "version": "0.2.2",
+  "description": "Homebridge module for Philips TV",
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jebabin/homebridge-philipstv-enhanced.git"
+    "url": "git+https://github.com/arkku/homebridge-philipstv-enhanced.git"
   },
   "dependencies": {
     "polling-to-event": "^2.0.2",
@@ -25,10 +25,10 @@
     "node": ">=0.12.0",
     "homebridge": ">=0.4.46"
   },
-  "author": "jebabin",
+  "author": "arkku",
   "license": "ISC",
   "bugs": {
-    "url": "https://github.com/jebabin/homebridge-philipstv-enhanced/issues"
+    "url": "https://github.com/arkku/homebridge-philipstv-enhanced/issues"
   },
-  "homepage": "https://github.com/jebabin/homebridge-philipstv-enhanced#readme"
+  "homepage": "https://github.com/arkku/homebridge-philipstv-enhanced#readme"
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homebridge-philipstv-enhanced",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Homebridge module for the Philips TV (with JointSpace enabled) and ready for 2018 models",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homebridge-philipstv-enhanced",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "Homebridge module for Philips TV",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homebridge-philipstv-enhanced",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "Homebridge module for the Philips TV (with JointSpace enabled) and ready for 2018 models",
   "main": "index.js",
   "scripts": {
@@ -23,7 +23,7 @@
   ],
   "engines": {
     "node": ">=0.12.0",
-    "homebridge": ">=0.2.0"
+    "homebridge": ">=0.4.46"
   },
   "author": "jebabin",
   "license": "ISC",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homebridge-philipstv-enhanced",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "Homebridge module for Philips TV",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
This patch changes the service type to Television, which allows controlling the TV from the iPhone Control Center remote widget, including simulating remote control buttons (cursors, ok, back and two configurable buttons) and adjusting volume with the phone's physical volume buttons.